### PR TITLE
add bidirectional raw stream multiplexing to yamux sessions

### DIFF
--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package xconn
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -41,6 +42,8 @@ type Server struct {
 	keepAliveInterval time.Duration
 	keepAliveTimeout  time.Duration
 	outQueueSize      int
+	yamuxConns        chan *YamuxConn
+	yamuxStreams      chan *YamuxStream
 }
 
 func NewServer(router *Router, authenticator auth.ServerAuthenticator, config *ServerConfig) *Server {
@@ -298,9 +301,26 @@ func (s *Server) Serve(listener net.Listener, protocol ListenerType) *Listener {
 	}
 }
 
+// YamuxListener is returned by ListenAndServeYamux.
+type YamuxListener struct {
+	*Listener
+	conns   <-chan *YamuxConn
+	streams <-chan *YamuxStream
+}
+
+// Conns receives one event per authenticated yamux client connection.
+func (l *YamuxListener) Conns() <-chan *YamuxConn {
+	return l.conns
+}
+
+// AcceptStream receives one event per raw stream opened by a client.
+func (l *YamuxListener) AcceptStream() <-chan *YamuxStream {
+	return l.streams
+}
+
 // ListenAndServeYamux starts a yamux listener. Each TCP connection is multiplexed.
 // The first stream carries WAMP, establishing an authenticated session.
-func (s *Server) ListenAndServeYamux(network Network, address string) (*Listener, error) {
+func (s *Server) ListenAndServeYamux(network Network, address string) (*YamuxListener, error) {
 	if network == NetworkUnix {
 		if err := ensureUnixSocketAvailable(address); err != nil {
 			return nil, err
@@ -311,8 +331,17 @@ func (s *Server) ListenAndServeYamux(network Network, address string) (*Listener
 		return nil, fmt.Errorf("failed to listen: %w", err)
 	}
 
+	conns := make(chan *YamuxConn, 8)
+	streams := make(chan *YamuxStream, 8)
+	s.yamuxConns = conns
+	s.yamuxStreams = streams
+
 	go s.startYamuxConnectionLoop(ln)
-	return &Listener{closer: ln, addr: ln.Addr()}, nil
+	return &YamuxListener{
+		Listener: &Listener{closer: ln, addr: ln.Addr()},
+		conns:    conns,
+		streams:  streams,
+	}, nil
 }
 
 func (s *Server) startYamuxConnectionLoop(ln net.Listener) {
@@ -329,7 +358,7 @@ func (s *Server) startYamuxConnectionLoop(ln net.Listener) {
 // HandleYamuxClient handles a single TCP connection as a yamux session.
 // The first accepted stream carries the WAMP protocol.
 func (s *Server) HandleYamuxClient(conn net.Conn) {
-	yamuxSess, err := yamux.Server(conn, nil)
+	yamuxSess, err := yamux.Server(conn, yamuxConfig())
 	if err != nil {
 		log.Debugf("failed to create yamux session: %v", err)
 		_ = conn.Close()
@@ -361,6 +390,18 @@ func (s *Server) HandleYamuxClient(conn net.Conn) {
 		return
 	}
 
+	// ctx is cancelled when this connection closes so Conns consumers can clean up.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if s.yamuxConns != nil {
+		s.yamuxConns <- &YamuxConn{Ctx: ctx, Session: base, Conn: &YamuxClientConn{yamuxSess: yamuxSess}}
+	}
+
+	if s.yamuxStreams != nil {
+		go s.acceptYamuxStreams(yamuxSess, base)
+	}
+
 	log.Debugf("attached yamux client %d", base.ID())
 
 	var limiter *ratelimit.Limiter
@@ -387,4 +428,14 @@ func (s *Server) HandleYamuxClient(conn net.Conn) {
 
 	_ = yamuxSess.Close()
 	log.Debugf("detached yamux client %d", base.ID())
+}
+
+func (s *Server) acceptYamuxStreams(yamuxSess *yamux.Session, base BaseSession) {
+	for {
+		stream, err := yamuxSess.Accept()
+		if err != nil {
+			return
+		}
+		s.yamuxStreams <- &YamuxStream{Session: base, Conn: stream}
+	}
 }

--- a/types.go
+++ b/types.go
@@ -1051,3 +1051,8 @@ func NewSessionDetails(
 type Authorizer interface {
 	Authorize(baseSession BaseSession, msg messages.Message) (bool, error)
 }
+
+// MultiplexedSession is implemented by session types that support opening raw streams alongside the WAMP connection.
+type MultiplexedSession interface {
+	OpenStream() (net.Conn, error)
+}

--- a/yamux.go
+++ b/yamux.go
@@ -3,6 +3,7 @@ package xconn
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"time"
 
@@ -12,10 +13,67 @@ import (
 	"github.com/xconnio/wampproto-go/transports"
 )
 
+// yamuxConfig returns a yamux config tuned for throughput.
+// The default 256 KB window stalls badly over high-latency links.
+// 4 MB gives enough headroom for typical internet paths without wasting memory.
+func yamuxConfig() *yamux.Config {
+	cfg := yamux.DefaultConfig()
+	cfg.MaxStreamWindowSize = 4 * 1024 * 1024 // 4 MB
+	cfg.LogOutput = io.Discard                // default writes to stderr
+	return cfg
+}
+
+// YamuxConn is delivered on YamuxListener.Conns when a yamux client connects and authenticates.
+// Ctx is cancelled when the client disconnects, allowing callers to clean up.
+type YamuxConn struct {
+	Ctx     context.Context
+	Session BaseSession
+	Conn    *YamuxClientConn
+}
+
+// YamuxStream is delivered on YamuxListener.AcceptStream when a client opens a raw stream.
+type YamuxStream struct {
+	Session BaseSession
+	net.Conn
+}
+
+// YamuxClientConn is the server-side handle for a connected yamux client.
+// It allows the server to open raw streams to the client.
+type YamuxClientConn struct {
+	yamuxSess *yamux.Session
+}
+
+// OpenStream opens a new raw stream to the connected yamux client.
+func (c *YamuxClientConn) OpenStream() (net.Conn, error) {
+	stream, err := c.yamuxSess.Open()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open yamux stream: %w", err)
+	}
+	return stream, nil
+}
+
 // YamuxSession is the client-side WAMP session over a yamux-multiplexed connection.
 type YamuxSession struct {
 	*Session
 	yamuxSess *yamux.Session
+}
+
+// OpenStream opens a new raw stream to the server for non-WAMP data transfer.
+func (y *YamuxSession) OpenStream() (net.Conn, error) {
+	stream, err := y.yamuxSess.Open()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open yamux stream: %w", err)
+	}
+	return stream, nil
+}
+
+// AcceptStream waits for the server to open a raw stream to this client.
+func (y *YamuxSession) AcceptStream() (net.Conn, error) {
+	stream, err := y.yamuxSess.Accept()
+	if err != nil {
+		return nil, fmt.Errorf("failed to accept yamux stream: %w", err)
+	}
+	return stream, nil
 }
 
 // Close sends a WAMP GOODBYE and closes the underlying yamux session.
@@ -67,7 +125,7 @@ func DialYamux(ctx context.Context, address, realm string, config *YamuxDialerCo
 		return nil, fmt.Errorf("failed to dial %s: %w", address, err)
 	}
 
-	yamuxSess, err := yamux.Client(conn, nil)
+	yamuxSess, err := yamux.Client(conn, yamuxConfig())
 	if err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("failed to create yamux session: %w", err)

--- a/yamux_test.go
+++ b/yamux_test.go
@@ -2,6 +2,7 @@ package xconn_test
 
 import (
 	"context"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -16,7 +17,7 @@ const (
 	prefixMatch   = "prefix"
 )
 
-func startYamuxRouter(t *testing.T) (addr string) {
+func startYamuxRouter(t *testing.T) (addr string, listener *xconn.YamuxListener) {
 	t.Helper()
 
 	router, err := xconn.NewRouter(nil)
@@ -38,15 +39,15 @@ func startYamuxRouter(t *testing.T) (addr string) {
 
 	server := xconn.NewServer(router, nil, nil)
 
-	listener, err := server.ListenAndServeYamux(xconn.NetworkTCP, "localhost:0")
+	listener, err = server.ListenAndServeYamux(xconn.NetworkTCP, "localhost:0")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = listener.Close() })
 
-	return listener.Addr().String()
+	return listener.Addr().String(), listener
 }
 
 func TestYamuxWAMPSession(t *testing.T) {
-	addr := startYamuxRouter(t)
+	addr, _ := startYamuxRouter(t)
 
 	sess, err := xconn.DialYamux(context.Background(), addr, realmName, nil)
 	require.NoError(t, err)
@@ -67,7 +68,7 @@ func TestYamuxWAMPSession(t *testing.T) {
 }
 
 func TestClientConnectYamux(t *testing.T) {
-	addr := startYamuxRouter(t)
+	addr, _ := startYamuxRouter(t)
 
 	client := xconn.Client{}
 	sess, err := client.ConnectYamux(context.Background(), addr, realmName)
@@ -82,7 +83,7 @@ func TestClientConnectYamux(t *testing.T) {
 }
 
 func TestDialYamuxWithJSONSerializer(t *testing.T) {
-	addr := startYamuxRouter(t)
+	addr, _ := startYamuxRouter(t)
 
 	sess, err := xconn.DialYamux(context.Background(), addr, realmName, &xconn.YamuxDialerConfig{
 		SerializerSpec: xconn.JSONSerializerSpec,
@@ -104,7 +105,7 @@ func TestDialYamuxWithJSONSerializer(t *testing.T) {
 }
 
 func TestYamuxSessionClose(t *testing.T) {
-	addr := startYamuxRouter(t)
+	addr, _ := startYamuxRouter(t)
 
 	sess, err := xconn.DialYamux(context.Background(), addr, realmName, nil)
 	require.NoError(t, err)
@@ -121,7 +122,7 @@ func TestYamuxSessionClose(t *testing.T) {
 // hold independent WAMP sessions on the same server.
 func TestYamuxMultipleClients(t *testing.T) {
 	const n = 5
-	addr := startYamuxRouter(t)
+	addr, _ := startYamuxRouter(t)
 
 	var wg sync.WaitGroup
 	for range n {
@@ -141,7 +142,7 @@ func TestYamuxMultipleClients(t *testing.T) {
 }
 
 func TestYamuxPublishSubscribe(t *testing.T) {
-	addr := startYamuxRouter(t)
+	addr, _ := startYamuxRouter(t)
 
 	subscriber, err := xconn.DialYamux(context.Background(), addr, realmName, nil)
 	require.NoError(t, err)
@@ -166,4 +167,185 @@ func TestYamuxPublishSubscribe(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("event not received")
 	}
+}
+
+func TestYamuxRawStream(t *testing.T) {
+	addr, listener := startYamuxRouter(t)
+
+	streamData := make(chan []byte, 1)
+	go func() {
+		stream := <-listener.AcceptStream()
+		buf, err := io.ReadAll(stream)
+		if err == nil {
+			streamData <- buf
+		}
+		_ = stream.Close()
+	}()
+
+	sess, err := xconn.DialYamux(context.Background(), addr, realmName, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	stream, err := sess.OpenStream()
+	require.NoError(t, err)
+
+	_, err = stream.Write([]byte("raw file data"))
+	require.NoError(t, err)
+	_ = stream.Close()
+
+	received := <-streamData
+	require.Equal(t, "raw file data", string(received))
+}
+
+func TestYamuxConnHandler(t *testing.T) {
+	addr, listener := startYamuxRouter(t)
+
+	// Server opens a stream to the client and writes a greeting.
+	go func() {
+		event := <-listener.Conns()
+		stream, err := event.Conn.OpenStream()
+		if err != nil {
+			return
+		}
+		_, _ = stream.Write([]byte("hello from server"))
+		_ = stream.Close()
+	}()
+
+	sess, err := xconn.DialYamux(context.Background(), addr, realmName, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	stream, err := sess.AcceptStream()
+	require.NoError(t, err)
+	defer stream.Close()
+
+	buf := make([]byte, 32)
+	n, err := stream.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, "hello from server", string(buf[:n]))
+}
+
+func TestYamuxStreamHasAuthenticatedSession(t *testing.T) {
+	addr, listener := startYamuxRouter(t)
+
+	sessionIDCh := make(chan uint64, 1)
+	go func() {
+		stream := <-listener.AcceptStream()
+		sessionIDCh <- stream.Session.ID()
+		_ = stream.Close()
+	}()
+
+	sess, err := xconn.DialYamux(context.Background(), addr, realmName, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	stream, err := sess.OpenStream()
+	require.NoError(t, err)
+	_ = stream.Close()
+
+	serverSessionID := <-sessionIDCh
+	require.NotZero(t, serverSessionID)
+}
+
+func TestYamuxConnHandlerContextCancelledOnClose(t *testing.T) {
+	addr, listener := startYamuxRouter(t)
+
+	ctxDone := make(chan struct{})
+	go func() {
+		event := <-listener.Conns()
+		<-event.Ctx.Done()
+		close(ctxDone)
+	}()
+
+	sess, err := xconn.DialYamux(context.Background(), addr, realmName, nil)
+	require.NoError(t, err)
+
+	_ = sess.Close()
+
+	select {
+	case <-ctxDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("YamuxConnEvent.Ctx was not cancelled after session close")
+	}
+}
+
+func TestYamuxMultipleConcurrentStreams(t *testing.T) {
+	const n = 5
+	addr, listener := startYamuxRouter(t)
+
+	for range n {
+		go func() {
+			stream := <-listener.AcceptStream()
+			defer stream.Close()
+			buf := make([]byte, 1)
+			if _, err := io.ReadFull(stream, buf); err != nil {
+				return
+			}
+			_, _ = stream.Write(buf)
+		}()
+	}
+
+	sess, err := xconn.DialYamux(context.Background(), addr, realmName, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			stream, err := sess.OpenStream()
+			require.NoError(t, err)
+			defer stream.Close()
+
+			sent := []byte{byte(i)}
+			_, err = stream.Write(sent)
+			require.NoError(t, err)
+
+			// Read the echo and verify it matches what we sent.
+			got := make([]byte, 1)
+			_, err = io.ReadFull(stream, got)
+			require.NoError(t, err)
+			require.Equal(t, sent, got)
+		}(i)
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("not all concurrent streams were handled")
+	}
+}
+
+func TestYamuxBidirectionalStream(t *testing.T) {
+	addr, listener := startYamuxRouter(t)
+
+	go func() {
+		stream := <-listener.AcceptStream()
+		defer stream.Close()
+		buf := make([]byte, 5)
+		if _, err := io.ReadFull(stream, buf); err != nil {
+			return
+		}
+		_, _ = stream.Write(buf)
+	}()
+
+	sess, err := xconn.DialYamux(context.Background(), addr, realmName, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	stream, err := sess.OpenStream()
+	require.NoError(t, err)
+	defer stream.Close()
+
+	_, err = stream.Write([]byte("hello"))
+	require.NoError(t, err)
+
+	buf := make([]byte, 5)
+	_, err = io.ReadFull(stream, buf)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(buf))
 }


### PR DESCRIPTION
Extends the yamux transport to support raw data streams alongside the WAMP session. Previously, yamux connections only carried WAMP messages on stream1. Now both the client and server can open additional streams for data transfer (e.g. file upload/download).